### PR TITLE
onCountChanged: fix wrong variable in second loop

### DIFF
--- a/DropDownInput/ChoosedTagItemsView.qml
+++ b/DropDownInput/ChoosedTagItemsView.qml
@@ -19,7 +19,7 @@ Flow{
                 for(var i = totalChoosed.tagChoosed.length; i !== 0; --i)
                     totalChoosed.tagChoosed.pop();
                 for(var j = 0; j < privateProps.tags.count; ++j)
-                    totalChoosed.tagChoosed.push(privateProps.tags.get(i).name);
+                    totalChoosed.tagChoosed.push(privateProps.tags.get(j).name);
             }
         }
 


### PR DESCRIPTION
The *privTags* ListModel rebuilds the *tagChoosed* list when the model count changes, by using 2 loops in the *onCountChanged()* function. The *privateProps.tags.get()* call in the second loop is wrong i think, it should be called with *j* and not *i*.